### PR TITLE
config: load external configuration from invenio

### DIFF
--- a/src/app/app.router.ts
+++ b/src/app/app.router.ts
@@ -9,6 +9,11 @@ const appRoutes: Routes = [
     component: EditorComponent,
     resolve: { editorData: RecordResolver },
   },
+  {
+    path: ':type',
+    component: EditorComponent,
+    resolve: { editorData: RecordResolver },
+  },
 ];
 
 @NgModule({

--- a/src/app/editor/editor.component.html
+++ b/src/app/editor/editor.component.html
@@ -3,7 +3,7 @@
     <span *ngSwitchCase="true">
       <i class="fa fa-check-circle success" aria-hidden="true"></i>
       <a
-        href="{{item.getIn(['record', '$ref'])}}"
+        href="{{ item.getIn(['record', '$ref']) }}"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -17,7 +17,10 @@
   </div>
 </ng-template>
 
-<app-record-toolbar (broadcast)="saveRecord($event)"></app-record-toolbar>
+<app-record-toolbar
+  (broadcast)="saveRecord($event)"
+  [name]="recordService.recordId ? 'Save' : 'Create'"
+></app-record-toolbar>
 
 <!--
   [(jsonPatches)]="editorData.patches"
@@ -25,7 +28,7 @@
 -->
 
 <json-editor
-  *ngIf="record && schema"
+  *ngIf="schema"
   [config]="config"
   [(record)]="record"
   [schema]="schema"

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -4,6 +4,7 @@ import { cloneDeep } from 'lodash';
 import { JsonEditorConfig } from 'ng2-json-editor';
 import 'rxjs/add/observable/zip';
 import { environment } from '../../environments/environment';
+import { RecordMetadata } from '../shared/interfaces/record.model';
 import { InvenioConfigService } from '../shared/services/invenio-config/invenio-config.service';
 import { RecordService } from '../shared/services/record.service';
 
@@ -14,8 +15,8 @@ import { RecordService } from '../shared/services/record.service';
   providers: [],
 })
 export class EditorComponent implements OnInit {
-  record: object;
   schema: object;
+  record: RecordMetadata;
   config: JsonEditorConfig = environment.editorConfig;
 
   constructor(
@@ -23,12 +24,16 @@ export class EditorComponent implements OnInit {
     public recordService: RecordService,
     public invenioConfigService: InvenioConfigService
   ) {
-    this.config = { ...this.config, ...this.invenioConfigService.data.editor_config };
+    this.config = { ...this.config, ...this.invenioConfigService.data.editorConfig };
   }
 
   saveRecord(event) {
-    this.recordService.save(this.record);
+    if (this.recordService.recordId) {
+      this.recordService.save(this.record);
+    }
+    this.recordService.create(this.record);
   }
+
 
   ngOnInit() {
     this.route.data.subscribe(data => {

--- a/src/app/editor/record-toolbar/record-toolbar.component.html
+++ b/src/app/editor/record-toolbar/record-toolbar.component.html
@@ -5,7 +5,7 @@
         <button class="btn navbar-btn btn-primary" (click)="broadcast.next($event)"
           placement="bottom" tooltip="Save your changes to the record">
           <i class="fa fa-floppy-o" aria-hidden="true"></i>&nbsp;
-          <span>Save</span>
+          <span>{{name}}</span>
         </button>
       </div>
     </div>

--- a/src/app/editor/record-toolbar/record-toolbar.component.ts
+++ b/src/app/editor/record-toolbar/record-toolbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-record-toolbar',
@@ -6,6 +6,9 @@ import { Component, Output, EventEmitter } from '@angular/core';
   styleUrls: ['./record-toolbar.component.scss'],
 })
 export class RecordToolbarComponent {
+  @Input()
+  name: string;
+
   @Output()
   broadcast = new EventEmitter();
 

--- a/src/app/shared/interfaces/index.ts
+++ b/src/app/shared/interfaces/index.ts
@@ -2,5 +2,5 @@ export { EditorData } from './editor-data.model';
 export { InvenioConfig, InvenioRecordConfig } from './invenio-config.model';
 export { PatchRequest } from './patch-request.model';
 export { ProblemMap } from './problem-map.model';
-export { Record } from './record.model';
+export { Record, RecordMetadata } from './record.model';
 

--- a/src/app/shared/interfaces/invenio-config.model.ts
+++ b/src/app/shared/interfaces/invenio-config.model.ts
@@ -7,6 +7,6 @@ export interface InvenioRecordConfig {
 
 // NOTE: Maybe should be renamed to ILS config since its specific
 export interface InvenioConfig {
-  editor_config: JsonEditorConfig;
-  record_config: InvenioRecordConfig;
+  editorConfig: JsonEditorConfig;
+  recordConfig: InvenioRecordConfig;
 }

--- a/src/app/shared/interfaces/record.model.ts
+++ b/src/app/shared/interfaces/record.model.ts
@@ -1,5 +1,7 @@
 export interface Record {
-  metadata?: {
-    $schema?: string;
-  };
+  metadata?: RecordMetadata;
+}
+
+export interface RecordMetadata {
+  $schema ?: string;
 }

--- a/src/app/shared/services/record.resolver.ts
+++ b/src/app/shared/services/record.resolver.ts
@@ -20,10 +20,13 @@ export class RecordResolver implements Resolve<any> {
       return this.recordMockService.getMockData();
     }
     if ('rec_id' in route.params) {
-      return this.recordService.fetchData(
+      return this.recordService.getRecord(
         route.params.rec_id,
-        this.invenioConfigService.data.record_config
+        this.invenioConfigService.data.recordConfig
       );
     }
+    return this.recordService.getNewRecord(
+      this.invenioConfigService.data.recordConfig
+    );
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -17,13 +17,13 @@
 
   <body>
     <!-- The invenio-records-editor will render a field like this passing
-    the configuration.  -->
+    the configuration. We also need authorized_token input -->
     <input
       type="hidden"
       id="invenio-records-editor"
       data-config='{
-        "editor_config": {"isPreviewerHiddenOnStart": true},
-        "record_config": {
+        "editorConfig": {"isPreviewerHiddenOnStart": true},
+        "recordConfig": {
           "apiUrl": "https://127.0.0.1:5000/api/items/",
           "schema": "https://127.0.0.1:5000/api/schemas/items/item-v1.0.0.json"
         }


### PR DESCRIPTION
* editor loads record and config from invenio
* the view url switched to :type/:id
* the url information is used by the editor in order to load the proper config for the relevant model
* upgraded ng2-json-editor to latest
* fixed instantiation test for service
* integrated patch request
* config: schema from invenio config
* load  schema from the configuration passed from invenio
* fixes to align with current implementation
* removed not found component
* implemented create record
* resolves #9